### PR TITLE
Apply standardized XML formatting

### DIFF
--- a/target-ontologies/bibliotek-o.owl
+++ b/target-ontologies/bibliotek-o.owl
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<rdf:RDF  
-    xmlns="http://bibliotek-o.org/ontology/"
-    xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns:owl="http://www.w3.org/2002/07/owl#"
-    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
-    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"  
-    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-    xmlns:vann="http://purl.org/vocab/vann/"
-    > 
-    
+<rdf:RDF xmlns="http://bibliotek-o.org/ontology/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:vann="http://purl.org/vocab/vann/">
     <!-- ONTOLOGY DECLARATION -->
-       
     <owl:Ontology rdf:about="http://bibliotek-o.org/ontology/">
         <owl:ontologyIRI rdf:resource="http://bibliotek-o.org/ontology/"/>
         <owl:versionIRI rdf:resource="http://bibliotek-o.org/1.1/ontology/"/>
@@ -19,12 +8,10 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-05T00:00:00-04:00</dcterms:modified>
         <rdfs:label xml:lang="en">bibliotek-o: a BIBFRAME 2 Ontology Extension</rdfs:label>
-        <rdfs:comment xml:lang="en">The bibliotek-o ontology extension defines additions and modifications to BIBFRAME 2 and is intended to be used as a supplement to the core BIBFRAME 2 ontology. In addition to the extension specification, bibliotek-o provides a set of recommended fragments from external ontologies and an application profile based on its recommended models and patterns. It is a joint product of the Mellon Foundation-funded Linked Data for Libraries - Labs and Linked Data for Production projects. See http://ld4l.org for more information on these projects.</rdfs:comment>        <vann:preferredNamespacePrefix>bib</vann:preferredNamespacePrefix>
+        <rdfs:comment xml:lang="en">The bibliotek-o ontology extension defines additions and modifications to BIBFRAME 2 and is intended to be used as a supplement to the core BIBFRAME 2 ontology. In addition to the extension specification, bibliotek-o provides a set of recommended fragments from external ontologies and an application profile based on its recommended models and patterns. It is a joint product of the Mellon Foundation-funded Linked Data for Libraries - Labs and Linked Data for Production projects. See http://ld4l.org for more information on these projects.</rdfs:comment>
+        <vann:preferredNamespacePrefix>bib</vann:preferredNamespacePrefix>
     </owl:Ontology>
-    
- 
     <!-- CLASSES -->
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AbbreviatedTitle">
         <rdfs:label xml:lang="en">Abbreviated title</rdfs:label>
         <skos:definition xml:lang="en">Title as abbreviated for citation, indexing, and/or identification.</skos:definition>
@@ -32,9 +19,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AbridgerActivity">
-        <rdfs:label xml:lang="en">Abridger</rdfs:label>    
+        <rdfs:label xml:lang="en">Abridger</rdfs:label>
         <skos:definition xml:lang="en">The activity of abridging a resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/abr.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -42,7 +28,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AccessibilityFeature">
         <rdfs:label xml:lang="en">Accessibility feature</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ContentAccessibility"/>
@@ -50,7 +35,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AccessibilityHazard">
         <rdfs:label xml:lang="en">Accessibility hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/ContentAccessibility"/>
@@ -58,25 +42,22 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AcquisitionActivity">
-        <rdfs:label xml:lang="en">Acquisition</rdfs:label>    
+        <rdfs:label xml:lang="en">Acquisition</rdfs:label>
         <skos:definition xml:lang="en">The activity of acquiring a resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is not derived from a MARC relator.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Activity">
-        <rdfs:label xml:lang="en">Activity</rdfs:label>    
+        <rdfs:label xml:lang="en">Activity</rdfs:label>
         <skos:definition xml:lang="en">An activity or contribution by a single agent that affects or alters the existence or state of a resource.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ActorActivity">
-        <rdfs:label xml:lang="en">Actor</rdfs:label>    
+        <rdfs:label xml:lang="en">Actor</rdfs:label>
         <skos:definition xml:lang="en">The activity of acting as a cast member or player in a musical or dramatic presentation, etc.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/act.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -84,9 +65,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AdapterActivity">
-        <rdfs:label xml:lang="en">Adapter</rdfs:label>    
+        <rdfs:label xml:lang="en">Adapter</rdfs:label>
         <skos:definition xml:lang="en">The activity of adapting a resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/adp.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -94,9 +74,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AddresseeActivity">
-        <rdfs:label xml:lang="en">Addressee</rdfs:label>    
+        <rdfs:label xml:lang="en">Addressee</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving an addressed resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rcp.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -104,18 +83,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AlternativeText">
-        <rdfs:label xml:lang="en">Alternative text</rdfs:label>    
+        <rdfs:label xml:lang="en">Alternative text</rdfs:label>
         <skos:definition xml:lang="en">Alternative text is provided for visual content (e.g., via the HTML alt attribute).</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class>    
-
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AnalystActivity">
-        <rdfs:label xml:lang="en">Analyst</rdfs:label>    
+        <rdfs:label xml:lang="en">Analyst</rdfs:label>
         <skos:definition xml:lang="en">The activity of analyzing data or information.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rcp.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -123,18 +100,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Annotations">
-        <rdfs:label xml:lang="en">Annotations</rdfs:label>    
+        <rdfs:label xml:lang="en">Annotations</rdfs:label>
         <skos:definition xml:lang="en">The resource includes annotations from the author, instructor and/or others.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class>  
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AnimatorActivity">
-        <rdfs:label xml:lang="en">Animator</rdfs:label>    
+        <rdfs:label xml:lang="en">Animator</rdfs:label>
         <skos:definition xml:lang="en">The activity of animating a resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/anm.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -142,20 +117,17 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <!-- No AnnotatorActivity class is defined to parallel http://id.loc.gov/vocabulary/relators/ann. Instead use the Web Annotation model -->
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ApertureCard">
-        <rdfs:label xml:lang="en">Aperture card</rdfs:label>    
+        <rdfs:label xml:lang="en">Aperture card</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a card with one or more rectangular openings or apertures holding frames of microfilm.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Card"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1021.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AppellantActivity">
-        <rdfs:label xml:lang="en">Appellant</rdfs:label>    
+        <rdfs:label xml:lang="en">Appellant</rdfs:label>
         <skos:definition xml:lang="en">The activity of appealing a court decision.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/apl.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -163,9 +135,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AppelleeActivity">
-        <rdfs:label xml:lang="en">Appellee</rdfs:label>    
+        <rdfs:label xml:lang="en">Appellee</rdfs:label>
         <skos:definition xml:lang="en">The activity of defending against an appeal.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/apl.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -173,9 +144,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ApplicantActivity">
-        <rdfs:label xml:lang="en">Applicant</rdfs:label>    
+        <rdfs:label xml:lang="en">Applicant</rdfs:label>
         <skos:definition xml:lang="en">The activity of going through an application process.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/app.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -183,9 +153,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArchitectActivity">
-        <rdfs:label xml:lang="en">Architect</rdfs:label>    
+        <rdfs:label xml:lang="en">Architect</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating an architectural design.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/arc.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -193,9 +162,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArrangerActivity">
-        <rdfs:label xml:lang="en">Arranger</rdfs:label>    
+        <rdfs:label xml:lang="en">Arranger</rdfs:label>
         <skos:definition xml:lang="en">The activity of arranging a musical resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/arr.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -203,9 +171,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArtCopyistActivity">
-        <rdfs:label xml:lang="en">Art copyist</rdfs:label>    
+        <rdfs:label xml:lang="en">Art copyist</rdfs:label>
         <skos:definition xml:lang="en">The activity of making copies of works of visual art.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/acp.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -213,9 +180,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArtDirectorActivity">
-        <rdfs:label xml:lang="en">Art director</rdfs:label>    
+        <rdfs:label xml:lang="en">Art director</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a motion picture or television production by overseeing the artists and craftspeople who build the sets.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/adi.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -223,9 +189,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArtistActivity">
-        <rdfs:label xml:lang="en">Artist</rdfs:label>    
+        <rdfs:label xml:lang="en">Artist</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a work by conceiving, and implementing, an original graphic design, drawing, painting, etc. For book illustrators, prefer IllustratorActivity.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/art.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -233,9 +198,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ArtisticDirectorActivity">
-        <rdfs:label xml:lang="en">Artistic director</rdfs:label>    
+        <rdfs:label xml:lang="en">Artistic director</rdfs:label>
         <skos:definition xml:lang="en">The activity of controlling the development of the artistic style of an entire production, including the choice of works to be presented and selection of senior production staff.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ard.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -243,9 +207,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AssigneeActivity">
-        <rdfs:label xml:lang="en">Assignee</rdfs:label>    
+        <rdfs:label xml:lang="en">Assignee</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving a transferred license for printing or publishing.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/asg.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -253,9 +216,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AttributionActivity">
-        <rdfs:label xml:lang="en">Attribution</rdfs:label>    
+        <rdfs:label xml:lang="en">Attribution</rdfs:label>
         <skos:definition xml:lang="en">The activity of which there is or once was substantial authority for designating that person as author, creator, etc. of the work indicative of provenance.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/att.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -263,27 +225,24 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioBelt">
-        <rdfs:label xml:lang="en">Audio belt</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio belt</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a loop of flexible plastic or magnetic film on which audio signals are mechanically recorded, commonly known under the trade name Dictabelt.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Belt"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1070.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioCartridge">
-        <rdfs:label xml:lang="en">Audio cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing an audio tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1002.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioCassette">
-        <rdfs:label xml:lang="en">Audio cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette containing an audiotape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
@@ -291,46 +250,40 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioCylinder">
-        <rdfs:label xml:lang="en">Audio cylinder</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio cylinder</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a roller-shaped object on which sound waves are incised or indented in a continuous circular groove.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cylinder"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1003.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
-    <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioDescription"> 
-        <rdfs:label xml:lang="en">Audio description</rdfs:label>   
+    <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioDescription">
+        <rdfs:label xml:lang="en">Audio description</rdfs:label>
         <skos:definition xml:lang="en">Audio descriptions are available (e.g., via the HTML5 track element).</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioDisc">
-        <rdfs:label xml:lang="en">Audio disc</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio disc</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a disc on which sound waves, recorded as modulations, pulses, etc., are incised or indented in a continuous spiral groove.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Disc"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1004.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioRoll">
-        <rdfs:label xml:lang="en">Audio roll</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio roll</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a roll of paper on which musical notes are represented by perforations, designed to mechanically reproduce the music when used in a player piano, player organ, etc.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Roll"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1006.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudiotapeReel">
-        <rdfs:label xml:lang="en">Audiotape reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Audiotape reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a roller-shaped object on which sound waves are incised or indented in a continuous circular groove.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
@@ -338,9 +291,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AudioWireReel">
-        <rdfs:label xml:lang="en">Audio wire reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Audio wire reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a reel or spool of steel or stainless steel wire upon which audio signals are magnetically recorded.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1008.</skos:scopeNote>
@@ -348,9 +300,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/AuthorActivity">
-        <rdfs:label xml:lang="en">Author</rdfs:label>    
+        <rdfs:label xml:lang="en">Author</rdfs:label>
         <skos:definition xml:lang="en">The activity of authoring a resource.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/aut.</skos:scopeNote>
@@ -358,17 +309,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Belt">
-        <rdfs:label xml:lang="en">Belt</rdfs:label>    
+        <rdfs:label xml:lang="en">Belt</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a loop on which signals are recorded.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/BinderActivity">
-        <rdfs:label xml:lang="en">Binder</rdfs:label>    
+        <rdfs:label xml:lang="en">Binder</rdfs:label>
         <skos:definition xml:lang="en">The activity of binding an item.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/bnd.</skos:scopeNote>
@@ -377,9 +326,8 @@
         <dcterms:modified>2017-05-05T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix rdfs:label (v1.0.1)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/BindingDesignerActivity">
-        <rdfs:label xml:lang="en">Binding designer</rdfs:label>    
+        <rdfs:label xml:lang="en">Binding designer</rdfs:label>
         <skos:definition xml:lang="en">The activity of designing a binding of a book, including the type of binding, the type of materials used, and any decorative aspects of the binding.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/bdd.</skos:scopeNote>
@@ -387,18 +335,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Bookmarks">
-        <rdfs:label xml:lang="en">Bookmarks</rdfs:label>    
+        <rdfs:label xml:lang="en">Bookmarks</rdfs:label>
         <skos:definition xml:lang="en">The resource includes bookmarks to facilitate navigation to key points.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class>    
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Braille">
-        <rdfs:label xml:lang="en">Braille</rdfs:label>    
+        <rdfs:label xml:lang="en">Braille</rdfs:label>
         <skos:definition xml:lang="en">Content of a resource in braille format.</skos:definition>
         <skos:scopeNote xml:lang="en">The feature of being in braille is both a notation and an accessibility feature.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
@@ -406,20 +352,18 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/BrailleAlternative">
-        <rdfs:label xml:lang="en">Braille alternative</rdfs:label>    
+        <rdfs:label xml:lang="en">Braille alternative</rdfs:label>
         <skos:definition xml:lang="en">Alternative content for a resource in braille.</skos:definition>
         <skos:scopeNote xml:lang="en">Differs from http://bibliotek-o.org/ontology/Braille, which types the notation of the resource itself, rather than the existence of alternative content.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/BroadcasterActivity">
-        <rdfs:label xml:lang="en">Broadcaster</rdfs:label>    
+        <rdfs:label xml:lang="en">Broadcaster</rdfs:label>
         <skos:definition xml:lang="en">The activity of broadcasting a resource via radio, television, webcast, etc.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/brd.</skos:scopeNote>
@@ -428,36 +372,32 @@
         <dcterms:modified>2017-05-05T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix rdfs:label (v1.0.1)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Captions">
-        <rdfs:label xml:lang="en">Captions</rdfs:label>    
+        <rdfs:label xml:lang="en">Captions</rdfs:label>
         <skos:definition xml:lang="en">Synchronized captions are available for audio and video content</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CaptureActivity">
-        <rdfs:label xml:lang="en">Capture</rdfs:label>    
+        <rdfs:label xml:lang="en">Capture</rdfs:label>
         <skos:definition xml:lang="en">The activity of recording, filming, etc. of a resource.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is not derived from the MARC relator.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Card">
-        <rdfs:label xml:lang="en">Card</rdfs:label>    
+        <rdfs:label xml:lang="en">Card</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a small sheet of opaque material.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1045.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CartographerActivity">
-        <rdfs:label xml:lang="en">Cartographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Cartographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a map, atlas, globe, or other cartographic work.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ctg.</skos:scopeNote>
@@ -465,34 +405,30 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Cartridge">
-        <rdfs:label xml:lang="en">Cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Cassette">
-        <rdfs:label xml:lang="en">Cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ChemMl">
-        <rdfs:label xml:lang="en">ChemML</rdfs:label>    
+        <rdfs:label xml:lang="en">ChemML</rdfs:label>
         <skos:definition xml:lang="en">Chemical information is encoded using the ChemML markup language</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ChoreographerActivity">
-        <rdfs:label xml:lang="en">Choreographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Choreographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating or contributing to a work of movement.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/chr.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -500,9 +436,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CinematographerActivity">
-        <rdfs:label xml:lang="en">Cinematographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Cinematographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of photographing a motion picture, who plans the technical aspets of lighting and photographing of scenes, and often assists the director in the choice of angles, camera setups, and lighting moods. He or she may also supervise the further processing of filmed material up to the completion of the work print. Cinematographer is also referred to as director of photography. Do not confuse with ld4l:VideographerActivity.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cng.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -510,9 +445,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CollectorActivity">
-        <rdfs:label xml:lang="en">Collector</rdfs:label>    
+        <rdfs:label xml:lang="en">Collector</rdfs:label>
         <skos:definition xml:lang="en">The activity of bringing together items from various sources that are then arranged, described, and cataloged as a collection. A collector is neither the creator of the material nor a person to whom manuscripts in the collection may have been addressed.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/col.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -520,9 +454,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CollectionRegistarActivity">
-        <rdfs:label xml:lang="en">Collection registrar</rdfs:label>    
+        <rdfs:label xml:lang="en">Collection registrar</rdfs:label>
         <skos:definition xml:lang="en">The activity of listing or inventorying the items in an aggregate work such as a collection of items or works.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cor.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -530,9 +463,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CollotyperActivity">
-        <rdfs:label xml:lang="en">Collotyper</rdfs:label>    
+        <rdfs:label xml:lang="en">Collotyper</rdfs:label>
         <skos:definition xml:lang="en">The activity of manufacturing a manifestation of photographic prints from film or other colloid that has ink-receptive and ink-repellent surfaces.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/clt.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -540,9 +472,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ColoristActivity">
-        <rdfs:label xml:lang="en">Colorist</rdfs:label>    
+        <rdfs:label xml:lang="en">Colorist</rdfs:label>
         <skos:definition xml:lang="en">The activity of applying color to drawings, prints, photographs, maps, moving images, etc.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/clr.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -550,9 +481,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CommentatorActivity">
-        <rdfs:label xml:lang="en">Commentator</rdfs:label>    
+        <rdfs:label xml:lang="en">Commentator</rdfs:label>
         <skos:definition xml:lang="en">The activity of providing interpretation, analysis, or a discussion of the subject matter on a recording, film, or other audiovisual medium.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cmm.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with Annotation pattern.</skos:editorialNote>
@@ -560,9 +490,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CompilerActivity">
-        <rdfs:label xml:lang="en">Compiler</rdfs:label>    
+        <rdfs:label xml:lang="en">Compiler</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a new work (e.g., a bibliography, a directory) through the act of compilation, e.g., selecting, arranging, aggregating, and editing data, information, etc.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/com.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -570,9 +499,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComposerActivity">
-        <rdfs:label xml:lang="en">Composer</rdfs:label>    
+        <rdfs:label xml:lang="en">Composer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating or contributing to a musical resource by adding music to a work that originally lacked it or supplements it.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cmp.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -580,9 +508,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerCard">
-        <rdfs:label xml:lang="en">Computer card</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer card</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a card containing digitally encoded data designed for use with a computer.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Electronic"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -590,18 +517,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerChip">
-        <rdfs:label xml:lang="en">Computer chip</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer chip</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a miniaturized electronic circuit on a small wafer of semiconductor silicon, designed to provide additional processing, memory, or storage capacity.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Electronic"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1012.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerChipCartridge">
-        <rdfs:label xml:lang="en">Computer chip cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer chip cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a miniaturized electronic circuit on a small wafer of semiconductor silicon, designed to provide additional processing, memory, or storage capacity.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/ComputerChip"/>
@@ -609,9 +534,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerDisc">
-        <rdfs:label xml:lang="en">Computer disc</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer disc</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a miniaturized electronic circuit on a small wafer of semiconductor silicon, designed to provide additional processing, memory, or storage capacity.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Electronic"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Disc"/>
@@ -619,9 +543,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerDiscCartridge">
-        <rdfs:label xml:lang="en">Computer disc cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer disc cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing one or more computer discs.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/ComputerDisc"/>
@@ -629,9 +552,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerTapeCartridge">
-        <rdfs:label xml:lang="en">Computer tape cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer tape cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a computer tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
@@ -640,9 +562,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerTapeCassette">
-        <rdfs:label xml:lang="en">Computer tape cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer tape cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette containing a computer tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
@@ -651,9 +572,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ComputerTapeReel">
-        <rdfs:label xml:lang="en">Computer tape reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Computer tape reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of an open reel holding a length of computer tape to be used with a computer tape drive.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Tape"/>
@@ -662,18 +582,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ConciseTitle">
         <rdfs:label xml:lang="en">Concise title</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
-        <skos:example xml:lang="en">&apos;Modern Writing&apos; could serve as the concise title for &apos;The Berkley Book of Modern Writing&apos;.</skos:example>
+        <skos:example xml:lang="en">'Modern Writing' could serve as the concise title for 'The Berkley Book of Modern Writing'.</skos:example>
         <skos:definition xml:lang="en">The concise version of a title.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ConductorActivity">
-        <rdfs:label xml:lang="en">Conductor</rdfs:label>    
+        <rdfs:label xml:lang="en">Conductor</rdfs:label>
         <skos:definition xml:lang="en">The activity of conducting a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cnd.</skos:scopeNote>
@@ -681,9 +599,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ConservatorActivity">
-        <rdfs:label xml:lang="en">Conservator</rdfs:label>    
+        <rdfs:label xml:lang="en">Conservator</rdfs:label>
         <skos:definition xml:lang="en">The activity of documenting, preserving, or treating printed or manuscript material, works of art, artifacts, or other media.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/con.</skos:scopeNote>
@@ -691,9 +608,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ConsultantActivity">
-        <rdfs:label xml:lang="en">Consultant</rdfs:label>    
+        <rdfs:label xml:lang="en">Consultant</rdfs:label>
         <skos:definition xml:lang="en">The activity of providing professional advice or services in a specialized field of knowledge or training.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/csl.</skos:scopeNote>
@@ -701,9 +617,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ContributorActivity">
-        <rdfs:label xml:lang="en">Contributor</rdfs:label>    
+        <rdfs:label xml:lang="en">Contributor</rdfs:label>
         <skos:definition xml:lang="en">The activity of making contributions to the resource. This includes those whose work has been contributed to a larger work, such as an anthology, serial publication, or other compilation of individual works. If a more specific role is available, prefer that activity type, e.g. ld4l:EditorActivity, ld4l:CompilerActivity, ld4l:IllustratorActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ctb.</skos:scopeNote>
@@ -711,9 +626,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CopyrightHolderActivity">
-        <rdfs:label xml:lang="en">Copyright holder</rdfs:label>    
+        <rdfs:label xml:lang="en">Copyright holder</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving copy and legal rights have been granted or transferred for the intellectual content of a work. The copyright holder, although not necessarily the creator of the work, usually has the exclusive right to benefit financially from the sale and use of the work to which the associated copyright protection applies.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cph.</skos:scopeNote>
@@ -721,9 +635,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CorrespondentActivity">
-        <rdfs:label xml:lang="en">Correspondent</rdfs:label>    
+        <rdfs:label xml:lang="en">Correspondent</rdfs:label>
         <skos:definition xml:lang="en">The activity of either the writer or recipient of a letter or other communication.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider separate activities for the writer and recipient.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/crp.</skos:scopeNote>
@@ -731,9 +644,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CoverDesignerActivity">
-        <rdfs:label xml:lang="en">Cover dsesigner</rdfs:label>    
+        <rdfs:label xml:lang="en">Cover dsesigner</rdfs:label>
         <skos:definition xml:lang="en">The activity of graphic design for a book cover, album cover, slipcase, box, container, etc. For a person or organization responsible for the graphic design of an entire book, use ld4l:DesignerActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cov.</skos:scopeNote>
@@ -741,9 +653,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CreatorActivity">
-        <rdfs:label xml:lang="en">Creator</rdfs:label>    
+        <rdfs:label xml:lang="en">Creator</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cre.</skos:scopeNote>
@@ -751,9 +662,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/CuratorActivity">
-        <rdfs:label xml:lang="en">Curator</rdfs:label>    
+        <rdfs:label xml:lang="en">Curator</rdfs:label>
         <skos:definition xml:lang="en">The activity of conceiving, aggregating, and/or organizing an exhibition, collection, or other item.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/cur.</skos:scopeNote>
@@ -761,17 +671,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Cylinder">
-        <rdfs:label xml:lang="en">Cylinder</rdfs:label>    
+        <rdfs:label xml:lang="en">Cylinder</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a roller-shaped object.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DancerActivity">
-        <rdfs:label xml:lang="en">Dancer</rdfs:label>    
+        <rdfs:label xml:lang="en">Dancer</rdfs:label>
         <skos:definition xml:lang="en">The activity of dancing in a musical, dramatic, etc., presentation.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dnc.</skos:scopeNote>
@@ -779,9 +687,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DedicateeActivity">
-        <rdfs:label xml:lang="en">Dedicatee</rdfs:label>    
+        <rdfs:label xml:lang="en">Dedicatee</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving a dedication.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with award/degree pattern.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dte.</skos:scopeNote>
@@ -789,9 +696,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DedicatorActivity">
-        <rdfs:label xml:lang="en">Dedicator</rdfs:label>    
+        <rdfs:label xml:lang="en">Dedicator</rdfs:label>
         <skos:definition xml:lang="en">The activity of making a dedication.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with award/degree pattern.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dto.</skos:scopeNote>
@@ -799,9 +705,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DepositorActivity">
-        <rdfs:label xml:lang="en">Depositor</rdfs:label>    
+        <rdfs:label xml:lang="en">Depositor</rdfs:label>
         <skos:definition xml:lang="en">The activity of depositing an item into the custody of another person, family, or organization, while still retaining ownership.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dpt.</skos:scopeNote>
@@ -809,18 +714,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DescribedMath">
-        <rdfs:label xml:lang="en">Described math</rdfs:label>    
+        <rdfs:label xml:lang="en">Described math</rdfs:label>
         <skos:definition xml:lang="en">Textual descriptions of math equations are included.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DesignerActivity">
-        <rdfs:label xml:lang="en">Designer</rdfs:label>    
+        <rdfs:label xml:lang="en">Designer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a design for an object.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dsr.</skos:scopeNote>
@@ -828,9 +731,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DirectorActivity">
-        <rdfs:label xml:lang="en">Director</rdfs:label>    
+        <rdfs:label xml:lang="en">Director</rdfs:label>
         <skos:definition xml:lang="en">The activity of general management and supervision of a filmed performance, a radio or television program, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/drt.</skos:scopeNote>
@@ -838,34 +740,30 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Disc">
-        <rdfs:label xml:lang="en">Disc</rdfs:label>    
+        <rdfs:label xml:lang="en">Disc</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a one or more discs.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DisplayTransformability">
-        <rdfs:label xml:lang="en">Display transformability</rdfs:label>    
+        <rdfs:label xml:lang="en">Display transformability</rdfs:label>
         <skos:definition xml:lang="en">Display properties are controllable by the user.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DistinctiveTitle">
         <rdfs:label xml:lang="en">Distinctive title</rdfs:label>
         <skos:definition xml:lang="en">Special title that appears in addition to the regular title on individual issues of an item and by which the issue may be known.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class>   
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DistributorActivity">
-        <rdfs:label xml:lang="en">Distributor</rdfs:label>    
+        <rdfs:label xml:lang="en">Distributor</rdfs:label>
         <skos:definition xml:lang="en">The activity of distributing a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dst.</skos:scopeNote>
@@ -873,9 +771,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DonorActivity">
-        <rdfs:label xml:lang="en">Donor</rdfs:label>    
+        <rdfs:label xml:lang="en">Donor</rdfs:label>
         <skos:definition xml:lang="en">The activity of donating an item to another owner.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/dst.</skos:scopeNote>
@@ -883,9 +780,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/DraftsmanActivity">
-        <rdfs:label xml:lang="en">Draftsman</rdfs:label>    
+        <rdfs:label xml:lang="en">Draftsman</rdfs:label>
         <skos:definition xml:lang="en">The activity of making detailed plans or drawings for buildings, ships, aircraft, machines, objects, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/drm.</skos:scopeNote>
@@ -893,9 +789,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/EditorActivity">
-        <rdfs:label xml:lang="en">Editor</rdfs:label>    
+        <rdfs:label xml:lang="en">Editor</rdfs:label>
         <skos:definition xml:lang="en">The activity of editing a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/edt.</skos:scopeNote>
@@ -903,9 +798,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/EngraverActivity">
-        <rdfs:label xml:lang="en">Engraver</rdfs:label>    
+        <rdfs:label xml:lang="en">Engraver</rdfs:label>
         <skos:definition xml:lang="en">The activity of cutting into a surface, such as a wooden or metal plate used for printing.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/egr.</skos:scopeNote>
@@ -913,9 +807,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/EtcherActivity">
-        <rdfs:label xml:lang="en">Etcher</rdfs:label>    
+        <rdfs:label xml:lang="en">Etcher</rdfs:label>
         <skos:definition xml:lang="en">The activity of producing text or images for printing by subjecting metal, glass, or some other surface to acid or the corrosive action of some other substance.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/etr.</skos:scopeNote>
@@ -923,9 +816,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FacsimilistActivity">
-        <rdfs:label xml:lang="en">Facsimilist</rdfs:label>    
+        <rdfs:label xml:lang="en">Facsimilist</rdfs:label>
         <skos:definition xml:lang="en">The activity of executing a facsimile.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider whether this activity subclass can be prunned; instead use an appropriate Activity subclass and state that resource is a facsimile.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/fac.</skos:scopeNote>
@@ -933,9 +825,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FieldDirectorActivity">
-        <rdfs:label xml:lang="en">Field director</rdfs:label>    
+        <rdfs:label xml:lang="en">Field director</rdfs:label>
         <skos:definition xml:lang="en">The activity of managing or supervising the work done to collect raw data or do research in an actual setting or environment (typically applies to the natural and social sciences).</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/fld.</skos:scopeNote>
@@ -943,17 +834,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Film">
-        <rdfs:label xml:lang="en">Film</rdfs:label>    
+        <rdfs:label xml:lang="en">Film</rdfs:label>
         <skos:definition xml:lang="en">An instance type containing a motion picture film.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmCartridge">
-        <rdfs:label xml:lang="en">Film cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Film cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a motion picture film.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
@@ -962,9 +851,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmCassette">
-        <rdfs:label xml:lang="en">Film cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Film cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette containing a motion picture film.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
@@ -973,9 +861,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmDistributorActivity">
-        <rdfs:label xml:lang="en">Film distributor</rdfs:label>    
+        <rdfs:label xml:lang="en">Film distributor</rdfs:label>
         <skos:definition xml:lang="en">The activity of distributing a moving image resource to theatres or other distribution channels.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/fds.</skos:scopeNote>
@@ -983,9 +870,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmEditor">
-        <rdfs:label xml:lang="en">Film editor</rdfs:label>    
+        <rdfs:label xml:lang="en">Film editor</rdfs:label>
         <skos:definition xml:lang="en">The activity of following the script and in creative cooperation with the Director, selects, arranges, and assembles the filmed material, controls the synchronization of picture and sound, and participates in other post-production tasks such as sound mixing and visual effects processing. Today, picture editing is often performed digitally..</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/flm.</skos:scopeNote>
@@ -993,9 +879,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmReel">
-        <rdfs:label xml:lang="en">Film reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Film reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of an open reel holding a motion picture film to be used with a motion picture film projector.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
@@ -1004,9 +889,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmRoll">
-        <rdfs:label xml:lang="en">Film roll</rdfs:label>    
+        <rdfs:label xml:lang="en">Film roll</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a wound length of film.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Roll"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
@@ -1015,9 +899,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmSlip">
-        <rdfs:label xml:lang="en">Film slip</rdfs:label>    
+        <rdfs:label xml:lang="en">Film slip</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a short strip of film, usually in rigid format rather than rolled.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1025,9 +908,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmStrip">
-        <rdfs:label xml:lang="en">Film strip</rdfs:label>    
+        <rdfs:label xml:lang="en">Film strip</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a roll of film, with or without recorded sound, containing a succession of images intended for projection one at a time.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1035,9 +917,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FilmStripCartridge">
-        <rdfs:label xml:lang="en">Film strip cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Film strip cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a filmstrip.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Film"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
@@ -1046,17 +927,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FlashingHazard">
-        <rdfs:label xml:lang="en">Flashing hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">Flashing hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/FlipChart">
-        <rdfs:label xml:lang="en">Flip chart</rdfs:label>    
+        <rdfs:label xml:lang="en">Flip chart</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a hinging device holding two or more sheets designed for use on an easel.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1064,9 +943,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ForgerActivity">
-        <rdfs:label xml:lang="en">Forger</rdfs:label>    
+        <rdfs:label xml:lang="en">Forger</rdfs:label>
         <skos:definition xml:lang="en">The activity of making or imitating something of value or importance, especially with the intent to defraud.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider whether this activity subclass can be prunned; instead use an appropriate Activity subclass and state that resource is a forgery.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/fac.</skos:scopeNote>
@@ -1074,25 +952,22 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/HighContrastAudio">
-        <rdfs:label xml:lang="en">High contrast audio</rdfs:label>    
+        <rdfs:label xml:lang="en">High contrast audio</rdfs:label>
         <skos:definition xml:lang="en">Audio content with speech in the foreground meets the contrast thresholds set out in WCAG Success Criteria 1.4.7.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/HighContrastDisplay">
-        <rdfs:label xml:lang="en">High contrast display</rdfs:label>    
+        <rdfs:label xml:lang="en">High contrast display</rdfs:label>
         <skos:definition xml:lang="en">Content meets the visual contrast threshold set out in WCAG Success Criteria 1.4.6.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/HonoreeActivity">
         <rdfs:label xml:lang="en">Honoree</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving an honor (e.g., the honoree of a festschrift, a person to whom a copy is presented).</skos:definition>
@@ -1102,9 +977,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/HostActivity">
-        <rdfs:label xml:lang="en">Host</rdfs:label>    
+        <rdfs:label xml:lang="en">Host</rdfs:label>
         <skos:definition xml:lang="en">The activity of leading a program (often broadcast) that includes other guests, performers, etc. (e.g., talk show host).</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/hst.</skos:scopeNote>
@@ -1112,9 +986,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/IlluminatorActivity">
-        <rdfs:label xml:lang="en">Illuminator</rdfs:label>    
+        <rdfs:label xml:lang="en">Illuminator</rdfs:label>
         <skos:definition xml:lang="en">The activity of decorating a specific item using precious metals or color, often with elaborate designs and motifs.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ilu.</skos:scopeNote>
@@ -1122,9 +995,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/IllustratorActivity">
-        <rdfs:label xml:lang="en">Illustrator</rdfs:label>    
+        <rdfs:label xml:lang="en">Illustrator</rdfs:label>
         <skos:definition xml:lang="en">The activity of illustrating a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ill.</skos:scopeNote>
@@ -1132,19 +1004,17 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/IndexAccessibilityFeature">
-        <rdfs:label xml:lang="en">Index accessibility feature</rdfs:label>    
+        <rdfs:label xml:lang="en">Index accessibility feature</rdfs:label>
         <skos:definition xml:lang="en">The accessibility feature of having an index.</skos:definition>
         <skos:scopeNote xml:lang="en">Refers to the feature of having an index, not to the index itself.</skos:scopeNote>
-        <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>        
+        <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/InscriberActivity">
-        <rdfs:label xml:lang="en">Inscriber</rdfs:label>    
+        <rdfs:label xml:lang="en">Inscriber</rdfs:label>
         <skos:definition xml:lang="en">The activity of writing a statement of dedication or gift.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship to annotation pattern.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ins.</skos:scopeNote>
@@ -1153,9 +1023,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/InstrumentalistActivity">
-        <rdfs:label xml:lang="en">Instrumentalist</rdfs:label>    
+        <rdfs:label xml:lang="en">Instrumentalist</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by playing a musical instrument.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Compare with Performed Music modeling work.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/itr.</skos:scopeNote>
@@ -1164,9 +1033,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/IntervieweeActivity">
-        <rdfs:label xml:lang="en">Interviewee</rdfs:label>    
+        <rdfs:label xml:lang="en">Interviewee</rdfs:label>
         <skos:definition xml:lang="en">The activity of responding to an interviewer, usually a reporter, pollster, or some other information gathering agent.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ive.</skos:scopeNote>
@@ -1174,9 +1042,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/InterviewerActivity">
-        <rdfs:label xml:lang="en">Interviewer</rdfs:label>    
+        <rdfs:label xml:lang="en">Interviewer</rdfs:label>
         <skos:definition xml:lang="en">The activity of gathering information as an interviewer, reporter, pollster, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ivr.</skos:scopeNote>
@@ -1184,9 +1051,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/InventorActivity">
-        <rdfs:label xml:lang="en">Inventor</rdfs:label>    
+        <rdfs:label xml:lang="en">Inventor</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a new device or process.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/inv.</skos:scopeNote>
@@ -1194,7 +1060,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/KeyTitle">
         <rdfs:label xml:lang="en">Key title</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
@@ -1202,27 +1067,24 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LargePrint">
-        <rdfs:label xml:lang="en">Large print</rdfs:label>    
+        <rdfs:label xml:lang="en">Large print</rdfs:label>
         <skos:definition xml:lang="en">The content has been formatted to meet large print guidelines.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LatexMathMl">
-        <rdfs:label xml:lang="en">LaTeXMathML</rdfs:label>    
+        <rdfs:label xml:lang="en">LaTeXMathML</rdfs:label>
         <skos:definition xml:lang="en">Mathematical equations and formulas are encoded using the LaTeXMathML markup language.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LenderActivity">
-        <rdfs:label xml:lang="en">Lender</rdfs:label>    
+        <rdfs:label xml:lang="en">Lender</rdfs:label>
         <skos:definition xml:lang="en">The activity of permitting the temporary use of a book, manuscript, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/len.</skos:scopeNote>
@@ -1230,9 +1092,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LibrettistActivity">
-        <rdfs:label xml:lang="en">Librettist</rdfs:label>    
+        <rdfs:label xml:lang="en">Librettist</rdfs:label>
         <skos:definition xml:lang="en">The activity of authoring a libretto of an opera or other stage work, or an oratorio.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/lbt.</skos:scopeNote>
@@ -1240,9 +1101,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LicenseeActivity">
-        <rdfs:label xml:lang="en">Licensee</rdfs:label>    
+        <rdfs:label xml:lang="en">Licensee</rdfs:label>
         <skos:definition xml:lang="en">The activity of receiving the right to print or publish.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with award/degree pattern.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/lse.</skos:scopeNote>
@@ -1250,9 +1110,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LicensorActivity">
-        <rdfs:label xml:lang="en">Licensor</rdfs:label>    
+        <rdfs:label xml:lang="en">Licensor</rdfs:label>
         <skos:definition xml:lang="en">The activity of signing of the license, imprimatur, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with award/degree pattern.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/lso.</skos:scopeNote>
@@ -1260,9 +1119,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LightingDesignerActivity">
-        <rdfs:label xml:lang="en">Lighting designer</rdfs:label>    
+        <rdfs:label xml:lang="en">Lighting designer</rdfs:label>
         <skos:definition xml:lang="en">The activity of designing the lighting scheme for a theatrical presentation, entertainment, motion picture, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/lgd.</skos:scopeNote>
@@ -1270,9 +1128,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LithographerActivity">
-        <rdfs:label xml:lang="en">Lithographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Lithographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of preparing the stone or plate for lithographic printing, including a graphic artist creating a design directly on the surface from which printing will be done.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ltg.</skos:scopeNote>
@@ -1280,18 +1137,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LongDescription">
-        <rdfs:label xml:lang="en">Long description</rdfs:label>    
+        <rdfs:label xml:lang="en">Long description</rdfs:label>
         <skos:definition xml:lang="en">Descriptions are provided for image-based visual content and/or complex structures such as tables, mathematics, diagrams and charts.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/LyricistActivity">
-        <rdfs:label xml:lang="en">Lyricist</rdfs:label>    
+        <rdfs:label xml:lang="en">Lyricist</rdfs:label>
         <skos:definition xml:lang="en">The activity of authoring the words of a non-dramatic musical work (e.g. the text of a song), except for oratorios.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/lyr.</skos:scopeNote>
@@ -1299,17 +1154,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MainTitleElement">
-        <rdfs:label xml:lang="en">Main title element</rdfs:label>   
+        <rdfs:label xml:lang="en">Main title element</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/TitleElement"/>
         <skos:definition xml:lang="en">The main part of a title.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ManufacturerActivity">
-        <rdfs:label xml:lang="en">Manufacturer</rdfs:label>    
+        <rdfs:label xml:lang="en">Manufacturer</rdfs:label>
         <skos:definition xml:lang="en">The activity of printing, duplicating, casting, etc. a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mfr.</skos:scopeNote>
@@ -1317,9 +1170,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MarblerActivity">
-        <rdfs:label xml:lang="en">Marbler</rdfs:label>    
+        <rdfs:label xml:lang="en">Marbler</rdfs:label>
         <skos:definition xml:lang="en">The activity of marbling paper, cloth, leather, etc. used in construction of a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mrb.</skos:scopeNote>
@@ -1327,16 +1179,14 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MathMl">
-        <rdfs:label xml:lang="en">MathML</rdfs:label>    
+        <rdfs:label xml:lang="en">MathML</rdfs:label>
         <skos:definition xml:lang="en">Mathematical equations and formulas are encoded using the MathML markup language.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Meeting">
         <rdfs:label xml:lang="en">Meeting</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
@@ -1345,9 +1195,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2016-04-21 (New)</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MetalEngraverActivity">
-        <rdfs:label xml:lang="en">Metal engraver</rdfs:label>    
+        <rdfs:label xml:lang="en">Metal engraver</rdfs:label>
         <skos:definition xml:lang="en">The activity of cutting on a metal surface in order to print decorations, illustrations, letters, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider whether this class is needed, or if ld4l:EngraverActivity is enough. If we need both, possibly make ld4l:MetalEngraverActivity a subclass of ld4l:Engraver.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mte.</skos:scopeNote>
@@ -1355,9 +1204,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Microfiche">
-        <rdfs:label xml:lang="en">Microfiche</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfiche</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a sheet of film bearing a number of microimages in a two-dimensional array.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microform"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1365,9 +1213,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicroficheCassette">
-        <rdfs:label xml:lang="en">Microfiche cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfiche cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette containing uncut microfiches.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microform"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
@@ -1376,17 +1223,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Microfilm">
-        <rdfs:label xml:lang="en">Microfilm</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm</rdfs:label>
         <skos:definition xml:lang="en">An instance type containing a microfilm.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microform"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicrofilmRoll">
-        <rdfs:label xml:lang="en">Microfilm roll</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm roll</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a wound length of microfilm.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microform"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Roll"/>
@@ -1395,9 +1240,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicrofilmCartridge">
-        <rdfs:label xml:lang="en">Microfilm cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a microfilm.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microfilm"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
@@ -1406,9 +1250,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicrofilmCassette">
-        <rdfs:label xml:lang="en">Microfilm cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cassette containing a microfilm.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microfilm"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
@@ -1417,9 +1260,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicrofilmReel">
-        <rdfs:label xml:lang="en">Microfilm reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of an open reel holding a microfilm, to be threaded into a microfilm reader.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microfilm"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
@@ -1428,9 +1270,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MicrofilmSlip">
-        <rdfs:label xml:lang="en">Microfilm reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Microfilm reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a short strip of microfilm cut from a roll.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microfilm"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1438,9 +1279,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Microform">
-        <rdfs:label xml:lang="en">Microform</rdfs:label>    
+        <rdfs:label xml:lang="en">Microform</rdfs:label>
         <skos:definition xml:lang="en">An instance type designed to store reduced-size images not readable to the human eye, designed for use with a device such as a microfilm or microfiche reader.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Media.</skos:editorialNote>
@@ -1448,9 +1288,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Microopaque">
-        <rdfs:label xml:lang="en">Microopaque</rdfs:label>    
+        <rdfs:label xml:lang="en">Microopaque</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a card or sheet of opaque material bearing a number of microimages in a two-dimensional array.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Microform"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1458,9 +1297,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Microscopic">
-        <rdfs:label xml:lang="en">Microscopic</rdfs:label>    
+        <rdfs:label xml:lang="en">Microscopic</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a small sheet of transparent material, with or without a protective mount, bearing a minute object designed for use with a device such as a microscope.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Slide"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1468,9 +1306,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MinuteTakerActivity">
-        <rdfs:label xml:lang="en">Minute taker</rdfs:label>    
+        <rdfs:label xml:lang="en">Minute taker</rdfs:label>
         <skos:definition xml:lang="en">The activity of recording the minutes of a meeting.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mtk.</skos:scopeNote>
@@ -1478,9 +1315,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ModeratorActivity">
-        <rdfs:label xml:lang="en">Moderator</rdfs:label>    
+        <rdfs:label xml:lang="en">Moderator</rdfs:label>
         <skos:definition xml:lang="en">The activity of leading a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider the relationship between this class and ld4l:HostActivity</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mod.</skos:scopeNote>
@@ -1488,9 +1324,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MonitorActivity">
-        <rdfs:label xml:lang="en">Monitor</rdfs:label>    
+        <rdfs:label xml:lang="en">Monitor</rdfs:label>
         <skos:definition xml:lang="en">The activity of supervising compliance with the contract and is responsible for the report and controls its distribution. Sometimes referred to as the grantee, or controlling agency.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mon.</skos:scopeNote>
@@ -1498,17 +1333,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MotionSimulationHazard">
-        <rdfs:label xml:lang="en">Motion simulation hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">Motion simulation hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MusicCopyistActivity">
-        <rdfs:label xml:lang="en">Music copyist</rdfs:label>    
+        <rdfs:label xml:lang="en">Music copyist</rdfs:label>
         <skos:definition xml:lang="en">The activity of transcribing or copying musical notation.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mcp.</skos:scopeNote>
@@ -1516,9 +1349,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MusicalDirectorActivity">
-        <rdfs:label xml:lang="en">Musical director</rdfs:label>    
+        <rdfs:label xml:lang="en">Musical director</rdfs:label>
         <skos:definition xml:lang="en">The activity of coordinating the activities of the composer, the sound editor, and sound mixers for a moving image production or for a musical or dramatic presentation or entertainment.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with ld4l:DirectorActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/msd.</skos:scopeNote>
@@ -1526,9 +1358,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/MusicianActivity">
-        <rdfs:label xml:lang="en">Musician</rdfs:label>    
+        <rdfs:label xml:lang="en">Musician</rdfs:label>
         <skos:definition xml:lang="en">The activity of performing music or contributes to the musical content of a work when it is not possible or desirable to identify the function more precisely.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with ld4l:InstrumentalistActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/mus.</skos:scopeNote>
@@ -1536,9 +1367,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/NarratorActivity">
-        <rdfs:label xml:lang="en">Narrator</rdfs:label>    
+        <rdfs:label xml:lang="en">Narrator</rdfs:label>
         <skos:definition xml:lang="en">The activity of narrating a  resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/nrt.</skos:scopeNote>
@@ -1546,47 +1376,41 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/NoFlashingHazard">
-        <rdfs:label xml:lang="en">No flashing hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">No flashing hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/NoMotionSimulationHazard">
-        <rdfs:label xml:lang="en">No motion simulation hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">No motion simulation hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/NonSortElement">
-        <rdfs:label xml:lang="en">Non-sort element</rdfs:label>   
+        <rdfs:label xml:lang="en">Non-sort element</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/TitleElement"/>
         <skos:definition xml:lang="en">The initial segment of a title that is removed for sorting.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class>       
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/NoSoundHazard">
-        <rdfs:label xml:lang="en">No sound hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">No sound hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class>  
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OclcIdentifier">
         <rdfs:label xml:lang="en-us">OCLC identifier</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Identifier"/>
         <skos:definition xml:lang="en-us">OCLC Worldcat identifier</skos:definition>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OfferActivity">
-        <rdfs:label xml:lang="en">Offer</rdfs:label>    
+        <rdfs:label xml:lang="en">Offer</rdfs:label>
         <skos:definition xml:lang="en">The activity of offering a resource for purchase or other form of acquisition. Use for Booksellers and sellers of other resources.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/bsl and http://id.loc.gov/vocabulary/relators/sll.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -1594,18 +1418,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OnlineResource">
-        <rdfs:label xml:lang="en">Online resource</rdfs:label>    
+        <rdfs:label xml:lang="en">Online resource</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a digital resource accessed by means of hardware and software connections to a communications network.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Electronic"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1018.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OpponentActivity">
-        <rdfs:label xml:lang="en">Opponent</rdfs:label>    
+        <rdfs:label xml:lang="en">Opponent</rdfs:label>
         <skos:definition xml:lang="en">The activity of opposing a thesis or dissertation.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/opn.</skos:scopeNote>
@@ -1613,16 +1435,14 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Origin">
-        <rdfs:label xml:lang="en">Origin</rdfs:label>    
+        <rdfs:label xml:lang="en">Origin</rdfs:label>
         <skos:definition xml:lang="en">The place from which a resource (e.g., a title) originates, such as spine, cover, container, etc.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OriginatorActivity">
-        <rdfs:label xml:lang="en">Originator</rdfs:label>    
+        <rdfs:label xml:lang="en">Originator</rdfs:label>
         <skos:definition xml:lang="en">The activity of performing the work, i.e., the name of a person or organization associated with the intellectual content of the work. This category does not include the publisher or personal affiliation, or sponsor except where it is also the corporate author.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider the relationship to other Activity subclasses, e.g. ld4l:CreatorActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/org.</skos:scopeNote>
@@ -1630,9 +1450,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OrganizerActivity">
-        <rdfs:label xml:lang="en">Organizer</rdfs:label>    
+        <rdfs:label xml:lang="en">Organizer</rdfs:label>
         <skos:definition xml:lang="en">The activity of organizing the exhibit, event, conference, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/orm.</skos:scopeNote>
@@ -1641,9 +1460,8 @@
         <dcterms:modified>2017-05-05T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix rdfs:label (v1.0.1)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OverheadTransparency">
-        <rdfs:label xml:lang="en">Overhead transparency</rdfs:label>    
+        <rdfs:label xml:lang="en">Overhead transparency</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a sheet of transparent material, with or without a protective mount, bearing an image designed for use with an overhead projector.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -1651,9 +1469,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/OwnerActivity">
-        <rdfs:label xml:lang="en">Owner</rdfs:label>    
+        <rdfs:label xml:lang="en">Owner</rdfs:label>
         <skos:definition xml:lang="en">The activity of owning an item or collection, i.e.has legal possession of a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship to ld4l:AcquisitionActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/own.</skos:scopeNote>
@@ -1661,9 +1478,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PanelistActivity">
-        <rdfs:label xml:lang="en">Panelist</rdfs:label>    
+        <rdfs:label xml:lang="en">Panelist</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by participating in a program (often broadcast) where topics are discussed, usually with participation of experts in fields related to the discussion.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pan.</skos:scopeNote>
@@ -1671,9 +1487,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PaperMakerActivity">
-        <rdfs:label xml:lang="en">Papermaker</rdfs:label>    
+        <rdfs:label xml:lang="en">Papermaker</rdfs:label>
         <skos:definition xml:lang="en">The activity of producing paper, usually from wood, cloth, or other fibrous material.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ppm.</skos:scopeNote>
@@ -1681,9 +1496,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PatentApplicantActivity">
-        <rdfs:label xml:lang="en">Patent applicant</rdfs:label>    
+        <rdfs:label xml:lang="en">Patent applicant</rdfs:label>
         <skos:definition xml:lang="en">The activity of appling for a patent.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pta.</skos:scopeNote>
@@ -1691,9 +1505,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PatentHolderActivity">
-        <rdfs:label xml:lang="en">Patent holder</rdfs:label>    
+        <rdfs:label xml:lang="en">Patent holder</rdfs:label>
         <skos:definition xml:lang="en">The activity of being granted a patent.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pth.</skos:scopeNote>
@@ -1701,9 +1514,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PatronActivity">
-        <rdfs:label xml:lang="en">Patron</rdfs:label>    
+        <rdfs:label xml:lang="en">Patron</rdfs:label>
         <skos:definition xml:lang="en">The activity of commissioning a work. Usually a patron uses his or her means or influence to support the work of artists, writers, etc. This includes those who commission and pay for individual works.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pat.</skos:scopeNote>
@@ -1711,7 +1523,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ParallelTitle">
         <rdfs:label xml:lang="en">Parallel title</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
@@ -1719,25 +1530,22 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PartNameElement">
-        <rdfs:label xml:lang="en">Part name element</rdfs:label>   
+        <rdfs:label xml:lang="en">Part name element</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/TitleElement"/>
         <skos:definition xml:lang="en">The part of a title that specifies the name of a part of the resource.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class>       
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PartNumberElement">
-        <rdfs:label xml:lang="en">Part number element</rdfs:label>   
+        <rdfs:label xml:lang="en">Part number element</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/TitleElement"/>
         <skos:definition xml:lang="en">The part of a title that specifies the number of a part of the resource.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PerformedMusic">
-        <rdfs:label xml:lang="en">Performed music</rdfs:label>    
+        <rdfs:label xml:lang="en">Performed music</rdfs:label>
         <skos:definition xml:lang="en">A work consisting of content expressed through music in an audible form.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA content type http://rdaregistry.info/termList/RDAContentType/1011.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Audio"/>
@@ -1745,9 +1553,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PerformerActivity">
-        <rdfs:label xml:lang="en">Performer</rdfs:label>    
+        <rdfs:label xml:lang="en">Performer</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by performing music, acting, dancing, speaking, etc., often in a musical or dramatic presentation, etc. If specific Activities are used, ld4l:PerformerActivity is used for a person whose principal skill is not known or specified.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with other "performance-based" activities. E.g. is every ld4l:ActorActivity a ld4l:PerformerActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prf.</skos:scopeNote>
@@ -1755,9 +1562,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PhotographerActivity">
-        <rdfs:label xml:lang="en">Photographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Photographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a photographic work.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pht.</skos:scopeNote>
@@ -1765,9 +1571,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PresenterActivity">
-        <rdfs:label xml:lang="en">Presenter</rdfs:label>    
+        <rdfs:label xml:lang="en">Presenter</rdfs:label>
         <skos:definition xml:lang="en">The activity of presenting a moving image, as in being mentioned in an “X presents” credit for moving image materials and who is associated with production, finance, or distribution in some way. A vanity credit; in early years, normally the head of a studio.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Not be be confused with a presenter of a presentation, for which we don't have a subclass.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pre.</skos:scopeNote>
@@ -1775,9 +1580,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PlatemakerActivity">
-        <rdfs:label xml:lang="en">Platemaker</rdfs:label>    
+        <rdfs:label xml:lang="en">Platemaker</rdfs:label>
         <skos:definition xml:lang="en">The activity of manufacturing a manifestation by preparing plates used in the production of printed images and/or text.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/plt.</skos:scopeNote>
@@ -1785,18 +1589,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PrintPageNumbers">
-        <rdfs:label xml:lang="en">Print page numbers</rdfs:label>    
+        <rdfs:label xml:lang="en">Print page numbers</rdfs:label>
         <skos:definition xml:lang="en">The resource includes equivalent print page numbers. Most commonly used with ebooks for which there is a print equivalent.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PrinterActivity">
-        <rdfs:label xml:lang="en">Printer</rdfs:label>    
+        <rdfs:label xml:lang="en">Printer</rdfs:label>
         <skos:definition xml:lang="en">The activity of manufacturing a manifestation of printed text, notated music, etc., from type or plates, such as a book, newspaper, magazine, broadside, score, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prt.</skos:scopeNote>
@@ -1804,9 +1606,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PrintmakerActivity">
-        <rdfs:label xml:lang="en">Printmaker</rdfs:label>    
+        <rdfs:label xml:lang="en">Printmaker</rdfs:label>
         <skos:definition xml:lang="en">The activity of making a relief, intaglio, or planographic printing surface.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with ld4l:PrinterActivity and ld4l:Platemaker</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prm.</skos:scopeNote>
@@ -1814,9 +1615,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ProducerActivity">
-        <rdfs:label xml:lang="en">Producer</rdfs:label>    
+        <rdfs:label xml:lang="en">Producer</rdfs:label>
         <skos:definition xml:lang="en">The activity of addressing the most of the business aspects of a production for screen, audio recording, television, webcast, etc. The producer is generally responsible for fund raising, managing the production, hiring key personnel, arranging for distributors, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pro.</skos:scopeNote>
@@ -1824,9 +1624,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ProductionActivity">
-        <rdfs:label xml:lang="en">Production personnel</rdfs:label>    
+        <rdfs:label xml:lang="en">Production personnel</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to the production aspects (props, lighting, special effects, etc.) of a musical or dramatic presentation or entertainment. When more specific activities are know use them, e.g. ld4l:Lighting Designer.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prd.</skos:scopeNote>
@@ -1834,9 +1633,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ProgrammerActivity">
-        <rdfs:label xml:lang="en">Programmer</rdfs:label>    
+        <rdfs:label xml:lang="en">Programmer</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a computer program.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prm.</skos:scopeNote>
@@ -1844,9 +1642,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Projected">
-        <rdfs:label xml:lang="en">Projected</rdfs:label>    
+        <rdfs:label xml:lang="en">Projected</rdfs:label>
         <skos:definition xml:lang="en">An instance type used to store moving or still images, designed for use with a projection device such as a motion picture film projector, slide projector, or overhead projector.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: Move appropriate Carrier types made into bf:Instance subclasses that intend use by projection to be subclasses of bf:Projected ; review with AV folks to get clarification.</skos:editorialNote>
@@ -1854,9 +1651,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ProofreaderActivity">
-        <rdfs:label xml:lang="en">Proofreader</rdfs:label>    
+        <rdfs:label xml:lang="en">Proofreader</rdfs:label>
         <skos:definition xml:lang="en">The activity of proofreading a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pfr.</skos:scopeNote>
@@ -1864,9 +1660,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ProviderActivity">
-        <rdfs:label xml:lang="en">Provider</rdfs:label>    
+        <rdfs:label xml:lang="en">Provider</rdfs:label>
         <skos:definition xml:lang="en">The activity of producing, publishing, manufacturing, or distributing a resource if specific Activities are not desired (e.g. ProducerActivity, PublisherActivity, ManufacturerActivity).</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship ld4l:OfferActivity.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/prv.</skos:scopeNote>
@@ -1874,9 +1669,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PublisherActivity">
-        <rdfs:label xml:lang="en">Publishing</rdfs:label>    
+        <rdfs:label xml:lang="en">Publishing</rdfs:label>
         <skos:definition xml:lang="en">The activity of publishing a resource.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/pbl.</skos:scopeNote>
@@ -1884,9 +1678,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/PuppeteerActivity">
-        <rdfs:label xml:lang="en">Puppeteer</rdfs:label>    
+        <rdfs:label xml:lang="en">Puppeteer</rdfs:label>
         <skos:definition xml:lang="en">The activity of manipulating, controlling, or directing puppets or marionettes in a moving image production or a musical or dramatic presentation or entertainment.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ppt.</skos:scopeNote>
@@ -1894,18 +1687,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ReadingOrder">
-        <rdfs:label xml:lang="en">Reading order</rdfs:label>    
+        <rdfs:label xml:lang="en">Reading order</rdfs:label>
         <skos:definition xml:lang="en">The reading order of the content is clearly defined (e.g., figures, sidebars and other secondary content have been marked up to allow it to be skipped automatically and/or manually escaped from.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/RecordistActivity">
-        <rdfs:label xml:lang="en">Recordist</rdfs:label>    
+        <rdfs:label xml:lang="en">Recordist</rdfs:label>
         <skos:definition xml:lang="en">The activity of using a recording device to capture sounds and/or video during a recording session, including field recordings of natural sounds, folkloric events, music, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rcd.</skos:scopeNote>
@@ -1913,17 +1704,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Reel">
-        <rdfs:label xml:lang="en">Reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a one or more reels.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/RendererActivity">
-        <rdfs:label xml:lang="en">Renderer</rdfs:label>    
+        <rdfs:label xml:lang="en">Renderer</rdfs:label>
         <skos:definition xml:lang="en">The activity of preparing drawings of architectural designs (i.e., renderings) in accurate, representational perspective to show what the project will look like when completed.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ren.</skos:scopeNote>
@@ -1931,9 +1720,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ReporterActivity">
-        <rdfs:label xml:lang="en">Reporter</rdfs:label>    
+        <rdfs:label xml:lang="en">Reporter</rdfs:label>
         <skos:definition xml:lang="en">The activity of writes or presents reports of news or current events on air or in print.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rpt.</skos:scopeNote>
@@ -1941,9 +1729,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/RepositoryActivity">
-        <rdfs:label xml:lang="en">Reporter</rdfs:label>    
+        <rdfs:label xml:lang="en">Reporter</rdfs:label>
         <skos:definition xml:lang="en">The activity of hosting data or material culture objects and provides services to promote long term, consistent and shared use of those data or objects.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with ldl4:AcquisitionActivity and bf:heldBy.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rps.</skos:scopeNote>
@@ -1951,9 +1738,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ResearcherActivity">
-        <rdfs:label xml:lang="en">Researcher</rdfs:label>    
+        <rdfs:label xml:lang="en">Researcher</rdfs:label>
         <skos:definition xml:lang="en">The activity of performing research.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/res.</skos:scopeNote>
@@ -1961,9 +1747,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ReviewerActivity">
-        <rdfs:label xml:lang="en">Reviewer</rdfs:label>    
+        <rdfs:label xml:lang="en">Reviewer</rdfs:label>
         <skos:definition xml:lang="en">The activity of reviewing of a book, motion picture, performance, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship to Annotations model.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/rev.</skos:scopeNote>
@@ -1971,27 +1756,24 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Roll">
-        <rdfs:label xml:lang="en">Roll</rdfs:label>    
+        <rdfs:label xml:lang="en">Roll</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a wound length of paper, film, tape, etc.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1047.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/RubyAnnotations">
-        <rdfs:label xml:lang="en">Ruby annotations</rdfs:label>    
+        <rdfs:label xml:lang="en">Ruby annotations</rdfs:label>
         <skos:definition xml:lang="en">Ruby annotations are provided in the content. Ruby annotations are used as pronunciation guides for the logographic characters for languages like Chinese or Japanese.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ScientificAdvisorActivity">
-        <rdfs:label xml:lang="en">Scientific advisor</rdfs:label>    
+        <rdfs:label xml:lang="en">Scientific advisor</rdfs:label>
         <skos:definition xml:lang="en">The activity of bringing scientific, pedagogical, or historical competence to the conception and realization on a work, particularly in the case of audio-visual items.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sad.</skos:scopeNote>
@@ -1999,9 +1781,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ScreenwriterAdvisorActivity">
-        <rdfs:label xml:lang="en">Screenwriter</rdfs:label>    
+        <rdfs:label xml:lang="en">Screenwriter</rdfs:label>
         <skos:definition xml:lang="en">The activity of authoring of a screenplay, script, or scene.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/aus.</skos:scopeNote>
@@ -2009,9 +1790,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ScribeActivity">
-        <rdfs:label xml:lang="en">Scribe</rdfs:label>    
+        <rdfs:label xml:lang="en">Scribe</rdfs:label>
         <skos:definition xml:lang="en">The activity of serving as an amanuensis and for a writer of manuscripts proper. For a person who makes pen-facsimiles, use FacsimilistActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/scr.</skos:scopeNote>
@@ -2019,19 +1799,17 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SculptorActivity">
-        <rdfs:label xml:lang="en">Sculptor</rdfs:label>    
+        <rdfs:label xml:lang="en">Sculptor</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a three-dimensional work by modeling, carving, or similar technique.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/scl.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SecretaryActivity">
-        <rdfs:label xml:lang="en">Secretary</rdfs:label>    
+        <rdfs:label xml:lang="en">Secretary</rdfs:label>
         <skos:definition xml:lang="en">The activity of recording, redacting, etc. in order to express the views of a organization. See also ld4l:MinutetakerActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sec.</skos:scopeNote>
@@ -2039,9 +1817,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SellerActivity">
-        <rdfs:label xml:lang="en">Seller</rdfs:label>    
+        <rdfs:label xml:lang="en">Seller</rdfs:label>
         <skos:definition xml:lang="en">The activity of selling something to another owner.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sll.</skos:scopeNote>
@@ -2049,9 +1826,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SetDesignerActivity">
-        <rdfs:label xml:lang="en">Set designer</rdfs:label>    
+        <rdfs:label xml:lang="en">Set designer</rdfs:label>
         <skos:definition xml:lang="en">The activity of translating the rough sketches of the art director into actual architectural structures for a theatrical presentation, entertainment, motion picture, etc. Set designers draw the detailed guides and specifications for building the set.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/std.</skos:scopeNote>
@@ -2059,9 +1835,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Sheet">
-        <rdfs:label xml:lang="en">Sheet</rdfs:label>    
+        <rdfs:label xml:lang="en">Sheet</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a flat, thin piece of paper, plastic, etc.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -2069,9 +1844,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SignerActivity">
-        <rdfs:label xml:lang="en">Signer</rdfs:label>    
+        <rdfs:label xml:lang="en">Signer</rdfs:label>
         <skos:definition xml:lang="en">The activity of signing a resource without a presentation or other statement indicative of provenance. When there is a presentation statement, use InscriberActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sgn.</skos:scopeNote>
@@ -2079,18 +1853,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SignLanguage">
-        <rdfs:label xml:lang="en">Sign language</rdfs:label>    
+        <rdfs:label xml:lang="en">Sign language</rdfs:label>
         <skos:definition xml:lang="en">Synchronized sign language intepretation is available for audio and video content.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SingerActivity">
-        <rdfs:label xml:lang="en">Singer</rdfs:label>    
+        <rdfs:label xml:lang="en">Singer</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by using his/her/their voice, with or without instrumental accompaniment, to produce music. A singer's performance may or may not include actual words.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sng.</skos:scopeNote>
@@ -2098,9 +1870,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Slide">
-        <rdfs:label xml:lang="en">Microscopic</rdfs:label>    
+        <rdfs:label xml:lang="en">Microscopic</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a small sheet of transparent material, usually in a protective mount, bearing an image designed for use with a slide projector or viewer.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -2108,17 +1879,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Software">
-        <rdfs:label xml:lang="en">Software</rdfs:label>    
+        <rdfs:label xml:lang="en">Software</rdfs:label>
         <skos:definition xml:lang="en">A compiled executable binary file.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SoundDesignerActivity">
-        <rdfs:label xml:lang="en">Sound designer</rdfs:label>    
+        <rdfs:label xml:lang="en">Sound designer</rdfs:label>
         <skos:definition xml:lang="en">The activity of producing and reproducing the sound score (both live and recorded), the installation of microphones, the setting of sound levels, and the coordination of sources of sound for a production.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sds.</skos:scopeNote>
@@ -2126,17 +1895,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SoundHazard">
-        <rdfs:label xml:lang="en">Sound hazard</rdfs:label>    
+        <rdfs:label xml:lang="en">Sound hazard</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityHazard"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Sounds">
-        <rdfs:label xml:lang="en">Sounds</rdfs:label>    
+        <rdfs:label xml:lang="en">Sounds</rdfs:label>
         <skos:definition xml:lang="en">A work consisting of content other than language or music, expressed in an audible form.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA content type http://rdaregistry.info/termList/RDAContentType/1012.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Audio"/>
@@ -2144,26 +1911,23 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SoundTrackReel">
-        <rdfs:label xml:lang="en">Sound track reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Sound track reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of an open reel holding a length of film on which sound is recorded.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA Carrier Type: http://rdaregistry.info/termList/RDACarrierType/1005.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SourceCode">
-        <rdfs:label xml:lang="en">Software</rdfs:label>    
+        <rdfs:label xml:lang="en">Software</rdfs:label>
         <skos:definition xml:lang="en">A text listing of commands to be compiled or assembled into an executable computer program.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Text"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SpeakerActivity">
-        <rdfs:label xml:lang="en">Speaker</rdfs:label>    
+        <rdfs:label xml:lang="en">Speaker</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by speaking words, such as a lecture, speech, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/spk.</skos:scopeNote>
@@ -2171,9 +1935,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SpokenWord">
-        <rdfs:label xml:lang="en">Spoken word</rdfs:label>    
+        <rdfs:label xml:lang="en">Spoken word</rdfs:label>
         <skos:definition xml:lang="en">A work consisting of content expressed through language in an audible form.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the RDA content type http://rdaregistry.info/termList/RDAContentType/1013.</skos:scopeNote>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Audio"/>
@@ -2181,9 +1944,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SponsorActivity">
-        <rdfs:label xml:lang="en">Sponsor</rdfs:label>    
+        <rdfs:label xml:lang="en">Sponsor</rdfs:label>
         <skos:definition xml:lang="en">The activity of sponsoring some aspect of a resource, e.g., funding research, sponsoring an event.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/spn.</skos:scopeNote>
@@ -2191,9 +1953,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StageDirectorActivity">
-        <rdfs:label xml:lang="en">Stage director</rdfs:label>    
+        <rdfs:label xml:lang="en">Stage director</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a stage resource through the overall management and supervision of a performance.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/sgd.</skos:scopeNote>
@@ -2201,9 +1962,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StageManagerActivity">
-        <rdfs:label xml:lang="en">Stage manager</rdfs:label>    
+        <rdfs:label xml:lang="en">Stage manager</rdfs:label>
         <skos:definition xml:lang="en">The activity of managing everything that occurs on a performance stage, and who acts as chief of all crews and assistant to a director during rehearsals.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/stm.</skos:scopeNote>
@@ -2211,9 +1971,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Stereographic">
-        <rdfs:label xml:lang="en">Stereograph</rdfs:label>    
+        <rdfs:label xml:lang="en">Stereograph</rdfs:label>
         <skos:definition xml:lang="en">A work made of pairs of still images, designed for use with a device such as a stereoscope or stereograph viewer to give the effect of three dimensions.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Work"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Media. Ask AV folks if this should be at bf:Instance level instead.</skos:editorialNote>
@@ -2221,9 +1980,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StereographCard">
-        <rdfs:label xml:lang="en">Stereograph card</rdfs:label>    
+        <rdfs:label xml:lang="en">Stereograph card</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a card bearing stereographic images.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Card"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -2231,9 +1989,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StereographDisc">
-        <rdfs:label xml:lang="en">Stereograph disc</rdfs:label>    
+        <rdfs:label xml:lang="en">Stereograph disc</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a card bearing stereographic images.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Disc"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -2241,9 +1998,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StereotyperActivity">
-        <rdfs:label xml:lang="en">Stereotyper</rdfs:label>    
+        <rdfs:label xml:lang="en">Stereotyper</rdfs:label>
         <skos:definition xml:lang="en">The activity of creating a new plate for printing by molding or copying another printing surface.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/str.</skos:scopeNote>
@@ -2251,9 +2007,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StorytellerActivity">
-        <rdfs:label xml:lang="en">Storyteller</rdfs:label>    
+        <rdfs:label xml:lang="en">Storyteller</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by relaying a creator's original story with dramatic or theatrical interpretation.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/stl.</skos:scopeNote>
@@ -2261,26 +2016,23 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/StructuralNavigation">
-        <rdfs:label xml:lang="en">Structural navigation</rdfs:label>    
+        <rdfs:label xml:lang="en">Structural navigation</rdfs:label>
         <skos:definition xml:lang="en">The use of headings in the resource fully and accurately reflects the document hierarchy, allowing navigation by assistive technologies.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SubtitleElement">
-        <rdfs:label xml:lang="en">Subtitle element</rdfs:label>   
+        <rdfs:label xml:lang="en">Subtitle element</rdfs:label>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/TitleElement"/>
         <skos:definition xml:lang="en">The subtitle of a title.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:Class>  
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SurveyorActivity">
-        <rdfs:label xml:lang="en">Surveyor</rdfs:label>    
+        <rdfs:label xml:lang="en">Surveyor</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a cartographic resource by providing measurements or dimensional relationships for the geographic area represented.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/srv.</skos:scopeNote>
@@ -2288,28 +2040,25 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/SynchronizedAudioText">
-        <rdfs:label xml:lang="en">Synchronized audio text</rdfs:label>    
+        <rdfs:label xml:lang="en">Synchronized audio text</rdfs:label>
         <skos:definition xml:lang="en">The resource offers both audio and text, with information that allows them to be rendered simultaneously.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TableOfContentsAccessibilityFeature">
-        <rdfs:label xml:lang="en">Table of contents accessibility feature</rdfs:label>    
+        <rdfs:label xml:lang="en">Table of contents accessibility feature</rdfs:label>
         <skos:definition xml:lang="en">Represents the feature of having a table of contents, rather than the table of contents itself.</skos:definition>
-        <skos:scopeNote xml:lang="en"></skos:scopeNote>
+        <skos:scopeNote xml:lang="en"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Tactile">
-        <rdfs:label xml:lang="en">Tactile</rdfs:label>    
+        <rdfs:label xml:lang="en">Tactile</rdfs:label>
         <skos:definition xml:lang="en">A work intended to be at least partially perceived with the sense of touch.</skos:definition>
         <skos:example xml:lang="en">The children's book Pat the Bunny.</skos:example>
         <skos:scopeNote xml:lang="en">Contrasts with http://id.loc.gov/ontologies/bibframe/TactileNotation, a notation used for transcribing a resource, such as braille.</skos:scopeNote>
@@ -2317,45 +2066,40 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TactileGraphic">
-        <rdfs:label xml:lang="en">Tactile graphic</rdfs:label>    
+        <rdfs:label xml:lang="en">Tactile graphic</rdfs:label>
         <skos:definition xml:lang="en">Tactile graphics are provided; for example, as described in the BANA Guidelines and Standards for Tactile Graphics.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TactileObject">
-        <rdfs:label xml:lang="en">Tactile object</rdfs:label>    
+        <rdfs:label xml:lang="en">Tactile object</rdfs:label>
         <skos:definition xml:lang="en">The content is a tactile 3D object, or the model to generate one is included.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/TactileNotation"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TaggedPdf">
-        <rdfs:label xml:lang="en">Tagged PDF</rdfs:label>    
+        <rdfs:label xml:lang="en">Tagged PDF</rdfs:label>
         <skos:definition xml:lang="en">The structures in a PDF have been tagged to improve the navigation of the content.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Tape">
-        <rdfs:label xml:lang="en">Tape</rdfs:label>    
+        <rdfs:label xml:lang="en">Tape</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of magnetic tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TeacherActivity">
-        <rdfs:label xml:lang="en">Teacher</rdfs:label>    
+        <rdfs:label xml:lang="en">Teacher</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by giving instruction or providing a demonstration.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/tch.</skos:scopeNote>
@@ -2363,9 +2107,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/ThesisAdvisorActivity">
-        <rdfs:label xml:lang="en">Thesis advisor</rdfs:label>    
+        <rdfs:label xml:lang="en">Thesis advisor</rdfs:label>
         <skos:definition xml:lang="en">The activity of supervising a degree candidate as they develop and present a thesis, mémoire, or text of a dissertation.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ths.</skos:scopeNote>
@@ -2373,25 +2116,22 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TimingControl">
-        <rdfs:label xml:lang="en">Timing control</rdfs:label>    
+        <rdfs:label xml:lang="en">Timing control</rdfs:label>
         <skos:definition xml:lang="en">For content with timed interaction, the user has the ability to control the timing to meet his or her needs (e.g., pause and reset).</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TitleElement">
-        <rdfs:label xml:lang="en">Title element</rdfs:label>    
+        <rdfs:label xml:lang="en">Title element</rdfs:label>
         <skos:definition xml:lang="en">A part of a title, such as a subtitle, part number, or part name.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TranscriberActivity">
-        <rdfs:label xml:lang="en">Transcriber</rdfs:label>    
+        <rdfs:label xml:lang="en">Transcriber</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by changing it from one system of notation to another. For a work transcribed for a different instrument or performing group, see ld4l:ArrangerActivity. For makers of pen-facsimiles, use ld4l:FacsimilistActivity.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/ths.</skos:scopeNote>
@@ -2399,18 +2139,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Transcript">
-        <rdfs:label xml:lang="en">Transcript</rdfs:label>    
+        <rdfs:label xml:lang="en">Transcript</rdfs:label>
         <skos:definition xml:lang="en">A transcript of the audio content is available.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TranslatorActivity">
-        <rdfs:label xml:lang="en">Translator</rdfs:label>    
+        <rdfs:label xml:lang="en">Translator</rdfs:label>
         <skos:definition xml:lang="en">The activity of rending a text from one language into another, or from an older form of a language into the modern form.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/trl.</skos:scopeNote>
@@ -2418,18 +2156,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TtsMarkup">
-        <rdfs:label xml:lang="en">TTS markup</rdfs:label>    
+        <rdfs:label xml:lang="en">TTS markup</rdfs:label>
         <skos:definition xml:lang="en">Markup has been used to enhance text-to-speech playback quality.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/TypographerActivity">
-        <rdfs:label xml:lang="en">Typographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Typographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of choosing and arranging the type used in an item. If the typographer is also responsible for other aspects of the graphic design of a book (e.g., ld4l:DesignerActivity), activities for both functions may be needed.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/tyg.</skos:scopeNote>
@@ -2437,18 +2173,16 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Unlocked">
-        <rdfs:label xml:lang="en">Unlocked</rdfs:label>    
+        <rdfs:label xml:lang="en">Unlocked</rdfs:label>
         <skos:definition xml:lang="en">No digital rights management or other content restriction protocols have been applied to the resource.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/AccessibilityFeature"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-11T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Fix superclass (v1.1.0)</skos:changeNote>
-    </owl:Class> 
-    
+    </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Video">
-        <rdfs:label xml:lang="en">Video</rdfs:label>    
+        <rdfs:label xml:lang="en">Video</rdfs:label>
         <skos:definition xml:lang="en">An instance type used to store moving or still images, designed for use with a playback device such as a videocassette player or DVD player.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Media.</skos:editorialNote>
@@ -2456,9 +2190,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VideoCartridge">
-        <rdfs:label xml:lang="en">Video cartridge</rdfs:label>    
+        <rdfs:label xml:lang="en">Video cartridge</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a video tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Video"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cartridge"/>
@@ -2468,9 +2201,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VideoCassette">
-        <rdfs:label xml:lang="en">Video cassette</rdfs:label>    
+        <rdfs:label xml:lang="en">Video cassette</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a cartridge containing a video tape.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Video"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Cassette"/>
@@ -2480,9 +2212,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VideoDisc">
-        <rdfs:label xml:lang="en">Video disc</rdfs:label>    
+        <rdfs:label xml:lang="en">Video disc</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of a disc on which video signals, with or without sound, are recorded.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Video"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Disc"/>
@@ -2491,9 +2222,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VideotapeReel">
-        <rdfs:label xml:lang="en">Videotape reel</rdfs:label>    
+        <rdfs:label xml:lang="en">Videotape reel</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of an open reel holding a video tape for use with reel-to-reel video equipment.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Video"/>
         <rdfs:subClassOf rdf:resource="http://bibliotek-o.org/ontology/Reel"/>
@@ -2504,7 +2234,7 @@
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VideographerActivity">
-        <rdfs:label xml:lang="en">Videographer</rdfs:label>    
+        <rdfs:label xml:lang="en">Videographer</rdfs:label>
         <skos:definition xml:lang="en">The activity of producing the video production, e.g. the video recording of a stage production as opposed to a commercial motion picture. The videographer may be the camera operator or may supervise one or more camera operators. Do not confuse with ld4l:CinematographerActivity.</skos:definition>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/vdg.</skos:scopeNote>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
@@ -2512,9 +2242,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/VoiceActorActivity">
-        <rdfs:label xml:lang="en">Voice actor</rdfs:label>    
+        <rdfs:label xml:lang="en">Voice actor</rdfs:label>
         <skos:definition xml:lang="en">The activity of contributing to a resource by providing the voice for characters in radio and audio productions and for animated characters in moving image works, as well as by providing voice overs in radio and television commercials, dubbed resources, etc.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/vac.</skos:scopeNote>
@@ -2522,9 +2251,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/Volume">
-        <rdfs:label xml:lang="en">Volume</rdfs:label>    
+        <rdfs:label xml:lang="en">Volume</rdfs:label>
         <skos:definition xml:lang="en">An instance type consisting of one or more sheets bound or fastened together to form a single unit.</skos:definition>
         <rdfs:subClassOf rdf:resource="http://id.loc.gov/ontologies/bibframe/Instance"/>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding RDA Carrier.</skos:editorialNote>
@@ -2532,9 +2260,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/WitnessActivity">
-        <rdfs:label xml:lang="en">Witness</rdfs:label>    
+        <rdfs:label xml:lang="en">Witness</rdfs:label>
         <skos:definition xml:lang="en">The activity of verifying the truthfulness of an event or action.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator.</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/wit.</skos:scopeNote>
@@ -2542,9 +2269,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-    
     <owl:Class rdf:about="http://bibliotek-o.org/ontology/WoodEngraverActivity">
-        <rdfs:label xml:lang="en">Wood engraver</rdfs:label>    
+        <rdfs:label xml:lang="en">Wood engraver</rdfs:label>
         <skos:definition xml:lang="en">The activity of making prints by cutting the image in relief on the end-grain of a wood block.</skos:definition>
         <skos:editorialNote xml:lang="en">Future work: consider more formal alignment between the class and corresponding MARC relator. Consider relationship with ld4l:PrintmakerActivity</skos:editorialNote>
         <skos:scopeNote xml:lang="en">This class is derived from the MARC relator: http://id.loc.gov/vocabulary/relators/wit.</skos:scopeNote>
@@ -2552,20 +2278,15 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:Class>
-
-
-
-    <!-- OBJECT PROPERTIES --> 
-
+    <!-- OBJECT PROPERTIES -->
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/atLocation">
         <rdfs:label xml:lang="en">at location</rdfs:label>
         <skos:definition xml:lang="en">The resource being described is at the specified location.</skos:definition>
-        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Location"/> 
+        <rdfs:range rdf:resource="http://www.w3.org/ns/prov#Location"/>
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/locationOf"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/covers">
         <rdfs:label xml:lang="en">covers</rdfs:label>
         <skos:definition xml:lang="en">Specifies a time period or location covered in the content of this resource.</skos:definition>
@@ -2573,8 +2294,7 @@
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/coveredIn"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:ObjectProperty> 
- 
+    </owl:ObjectProperty>
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/coveredIn">
         <rdfs:label xml:lang="en">covered in</rdfs:label>
         <skos:definition xml:lang="en">Specifies a resource the content of which covers this time period or location.</skos:definition>
@@ -2583,7 +2303,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/grantedBy">
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <skos:definition xml:lang="en">Specifies an agent granting a degree, award, or similar resource.</skos:definition>
@@ -2592,7 +2311,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/grants">
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
         <skos:definition xml:lang="en">Specifies a degree, award, or similar resource granted by this agent.</skos:definition>
@@ -2601,16 +2319,14 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasActivity">
         <rdfs:label xml:lang="en">has activity</rdfs:label>
         <skos:definition xml:lang="en">Relates this resource to an activity or contribution by a single agent that affects or alters its existence or state.</skos:definition>
-        <rdfs:range rdf:resource="http://bibliotek-o.org/ontology/Activity"/> 
+        <rdfs:range rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/isActivityOf"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasAgent">
         <rdfs:label xml:lang="en">has agent</rdfs:label>
         <skos:definition xml:lang="en">Relates an activity to its agent.</skos:definition>
@@ -2620,7 +2336,6 @@
         <dcterms:modified>2017-05-16T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Remove domain specification (v1.1.0)</skos:changeNote>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/heldBy">
         <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
@@ -2630,7 +2345,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2016-04-21 (New)</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/holds">
         <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
@@ -2640,22 +2354,19 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2016-04-21 (New)</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasCoverArt">
         <rdfs:label xml:lang="en">has cover art</rdfs:label>
         <skos:definition xml:lang="en">Specifies the cover art of the resource.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasOrigin">
-        <rdfs:label xml:lang="en">has origin</rdfs:label>    
+        <rdfs:label xml:lang="en">has origin</rdfs:label>
         <skos:definition xml:lang="en">Specifies the physical location from which this resource (e.g., a title) originates, such as spine, cover, container, etc.</skos:definition>
         <skos:scopeNote xml:lang="en">Distinct from http://bibliotek-o.org/ontology/hasSource, which specifies an external organization or scheme from which the resource was obtained.</skos:scopeNote>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasPreferredTitle">
         <rdfs:label xml:lang="en">has preferred title</rdfs:label>
         <skos:definition xml:lang="en">Specifies the preferred title of this resource.</skos:definition>
@@ -2664,7 +2375,6 @@
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/isPreferredTitleOf"/>
         <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/hasSource">
         <rdfs:label xml:lang="en">has source</rdfs:label>
         <skos:definition xml:lang="en">Relates this resource to the source from which it was derived.</skos:definition>
@@ -2673,7 +2383,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/heldBy">
         <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
         <rdfs:range rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
@@ -2683,7 +2392,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/holds">
         <rdfs:range rdf:resource="http://id.loc.gov/ontologies/bibframe/Item"/>
         <rdfs:domain rdf:resource="http://xmlns.com/foaf/0.1/Agent"/>
@@ -2693,16 +2401,14 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isActivityOf">
         <rdfs:label xml:lang="en">has activity</rdfs:label>
         <skos:definition xml:lang="en">Relates an activity to the affected resource.</skos:definition>
-        <rdfs:domain rdf:resource="http://bibliotek-o.org/ontology/Activity"/> 
+        <rdfs:domain rdf:resource="http://bibliotek-o.org/ontology/Activity"/>
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/hasActivity"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isAgentOf">
         <rdfs:label xml:lang="en">is agent of</rdfs:label>
         <skos:definition xml:lang="en">Relates an agent to the activity it participated in.</skos:definition>
@@ -2712,7 +2418,6 @@
         <dcterms:modified>2017-05-16T00:00:00-04:00</dcterms:modified>
         <skos:changeNote xml:lang="en">Remove range specification (v1.1.0)</skos:changeNote>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isLocationOf">
         <rdfs:label xml:lang="en">is location of</rdfs:label>
         <skos:definition xml:lang="en">The specified resource is at the location being described.</skos:definition>
@@ -2721,7 +2426,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isPreferredTitleOf">
         <rdfs:label xml:lang="en">is preferred title of</rdfs:label>
         <skos:definition xml:lang="en">Specifies the resource for which this is the preferred title.</skos:definition>
@@ -2730,33 +2434,29 @@
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/hasPreferredTitle"/>
         <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isSourceOf">
         <rdfs:label xml:lang="en">is source of</rdfs:label>
         <skos:definition xml:lang="en">Relates this resource to a resource of which it is the source.</skos:definition>
-        <skos:scopeNote xml:lang="en">Has general applicability to many types of sources and resources.</skos:scopeNote>        
+        <skos:scopeNote xml:lang="en">Has general applicability to many types of sources and resources.</skos:scopeNote>
         <owl:inverseOf rdf:resource="http://bibliotek-o.org/ontology/hasSource"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isSubjectOf">
         <rdfs:label xml:lang="en">is subject of</rdfs:label>
-        <skos:definition xml:lang="en">Specifies a subject of this resource.</skos:definition>      
+        <skos:definition xml:lang="en">Specifies a subject of this resource.</skos:definition>
         <owl:inverseOf rdf:resource="http://purl.org/dc/terms/subject"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isTargetOf">
         <rdfs:label xml:lang="en">is target of</rdfs:label>
         <skos:definition xml:lang="en">Relates a resource to its Annotation.</skos:definition>
-        <rdfs:range rdf:resource="http://www.w3.org/ns/oa#Annotation"/> 
+        <rdfs:range rdf:resource="http://www.w3.org/ns/oa#Annotation"/>
         <owl:inverseOf rdf:resource="http://www.w3.org/ns/oa#hasTarget"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:ObjectProperty>   
- 
+    </owl:ObjectProperty>
     <owl:ObjectProperty rdf:about="http://bibliotek-o.org/ontology/isTitleOf">
         <rdfs:domain rdf:resource="http://id.loc.gov/ontologies/bibframe/Title"/>
         <owl:inverseOf rdf:resource="http://id.loc.gov/ontologies/bibframe/title"/>
@@ -2766,12 +2466,8 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:ObjectProperty>
-    
-    
     <!-- NAMED INDIVIDUALS -->
-
     <!-- Type http://www.w3.org/ns/oa#Motivation -->
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/cataloging">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">cataloging</rdfs:label>
@@ -2780,7 +2476,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/linkingTableOfContents">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">linking table of contents</rdfs:label>
@@ -2789,7 +2484,6 @@
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
         <skos:broader rdf:resource="http://www.w3.org/ns/oa#linking"/>
     </owl:NamedIndividual>
- 
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/listing">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">listing</rdfs:label>
@@ -2798,7 +2492,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/listingCredits">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">listing credits</rdfs:label>
@@ -2807,7 +2500,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/providingPurpose">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">providing purpose</rdfs:label>
@@ -2816,7 +2508,6 @@
         <dcterms:issued>2017-05-17T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-05-17T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/reviewing">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">reviewing</rdfs:label>
@@ -2824,8 +2515,7 @@
         <skos:broader rdf:resource="http://www.w3.org/ns/oa#assessing"/>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
-    </owl:NamedIndividual> 
-    
+    </owl:NamedIndividual>
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifying">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying</rdfs:label>
@@ -2834,7 +2524,6 @@
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
         <skos:broader rdf:resource="http://www.w3.org/ns/oa#describing"/>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingContents">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying contents</rdfs:label>
@@ -2843,7 +2532,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingCustodialHistory">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying custodial history</rdfs:label>
@@ -2852,7 +2540,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingHistoryOfWork">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying history of work</rdfs:label>
@@ -2861,7 +2548,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingNatureOfContent">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying nature of content</rdfs:label>
@@ -2870,7 +2556,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingPreferredCitation">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying preferred citation</rdfs:label>
@@ -2879,7 +2564,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/specifyingSystemRequirements">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">specifying system requirements</rdfs:label>
@@ -2888,7 +2572,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/summarizing">
         <rdf:type rdf:resource="http://www.w3.org/ns/oa#Motivation"/>
         <rdfs:label xml:lang="en">summarizing</rdfs:label>
@@ -2897,29 +2580,22 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
-    
     <!-- Type http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic -->
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/threeDimensionalProjectionCharacteristic">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"/>
-        <rdfs:label xml:lang="en">three dimensional projection characteric</rdfs:label>    
+        <rdfs:label xml:lang="en">three dimensional projection characteric</rdfs:label>
         <skos:definition xml:lang="en">Projected images intended to be perceived to be moving, and in three dimensions.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/twoDimensionalProjectionCharacteristic">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/ProjectionCharacteristic"/>
-        <rdfs:label xml:lang="en">two dimensional projection characteristic</rdfs:label>    
+        <rdfs:label xml:lang="en">two dimensional projection characteristic</rdfs:label>
         <skos:definition xml:lang="en">Projected images intended to be perceived to be moving, and in two dimensions.</skos:definition>
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
- 
-    
     <!-- Type http://id.loc.gov/ontologies/bibframe/Status -->
-
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/cancelled">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Status"/>
         <rdfs:label xml:lang="en">status</rdfs:label>
@@ -2927,7 +2603,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/current">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Status"/>
         <rdfs:label xml:lang="en">current</rdfs:label>
@@ -2935,7 +2610,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/deprecated">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Status"/>
         <rdfs:label xml:lang="en">deprecated</rdfs:label>
@@ -2943,7 +2617,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
- 
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/invalid">
         <rdf:type rdf:resource="http://id.loc.gov/ontologies/bibframe/Status"/>
         <rdfs:label xml:lang="en">invalid</rdfs:label>
@@ -2951,10 +2624,7 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
-    
     <!-- Type http://bibliotek-o.org/ontology/Origin -->
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/addedTitlePage">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">added title page</rdfs:label>
@@ -2962,7 +2632,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/binder">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">binder</rdfs:label>
@@ -2970,7 +2639,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/caption">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">caption</rdfs:label>
@@ -2978,7 +2646,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/container">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">container</rdfs:label>
@@ -2986,7 +2653,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/cover">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">cover</rdfs:label>
@@ -2994,7 +2660,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/margin">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">margin</rdfs:label>
@@ -3002,7 +2667,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/spine">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">spine</rdfs:label>
@@ -3010,7 +2674,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/supplied">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">supplied</rdfs:label>
@@ -3018,7 +2681,6 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
     <owl:NamedIndividual rdf:about="http://bibliotek-o.org/ontology/transcribed">
         <rdf:type rdf:resource="http://bibliotek-o.org/ontology/Origin"/>
         <rdfs:label xml:lang="en">transcribed</rdfs:label>
@@ -3026,6 +2688,4 @@
         <dcterms:issued>2017-04-22T00:00:00-04:00</dcterms:issued>
         <dcterms:modified>2017-04-22T00:00:00-04:00</dcterms:modified>
     </owl:NamedIndividual>
-    
 </rdf:RDF>
-


### PR DESCRIPTION
Fix #47 

The aim of this PR is to apply a standardized XML format to the ontology file.  This can help to avoid whitespace changes to the ontology in PRs.  This particular PR uses 4-space indentation:
```
XMLLINT_INDENT="    " xmllint --format target-ontologies/bibliotek-o.owl
```
Other standardized formats may be preferred.  If there is a way to get a standardized format that allows one line spaces between the major OWL elements (class, property etc.), that would be ideal, it's just not obvious to me at the moment.

PS, I might look into suggestions on this SO answer about using an XSLT stylesheet to achieve a similar layout to the existing layout, only automatically applied:
- https://stackoverflow.com/a/7336726/1172685